### PR TITLE
Added Upload Data and Logs to S3 Bucket on Invocation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: '3.8'
           
       - name: Zip Source Code
-        run: zip -r WolfOfRobinhood.zip ./ -x 'tests/*';
+        run: zip -r wolf-of-robinhood-prod.zip ./ -x 'tests/*';
 
       - name: Deploy to AWS Lambda
         uses: appleboy/lambda-action@v0.1.5
@@ -27,5 +27,5 @@ jobs:
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: ${{ secrets.AWS_REGION }}
-          function_name: WolfOfRobinhood
-          zip_file: WolfOfRobinhood.zip
+          function_name: wolf-of-robinhood-prod
+          zip_file: wolf-of-robinhood-prod.zip

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ coverage.xml
 *.sh
 .coverage
 **/__pycache__/**
-test_local.py # .py file to test lambda function locally
+test_local.py
+data.csv
+logs.log

--- a/Pipfile
+++ b/Pipfile
@@ -21,6 +21,7 @@ pytest = "*"
 pytest-cov = "*"
 mock = "*"
 moto = "*"
+freezegun = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "27707f739f3cb43c9641278c3c6db2a787cac7a094b44f368ccabc68707f5668"
+            "sha256": "534d2abb49d0f898922747d164d62df59641f8932f4699f1be2dcd6cd8b67d67"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,35 +18,35 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:a2ffce001160d7e7c72a90c3084700d50eb64ea4a3aae8afe21566971d1fd611",
-                "sha256:d7effba509d7298ef49316ba2da7a2ea115f2a7ff691f875f6354666663cf386"
+                "sha256:1c6301d9676cb18f2b0feddec393e52b9d5fa8147e6fe9a1665e39fd9739efc3",
+                "sha256:6a8111492a571aeefbac2e4b6df5ce38bdbc16c7d8326f2a60a61c86032c49b0"
             ],
             "index": "pypi",
-            "version": "==1.20.46"
+            "version": "==1.20.48"
         },
         "boto3-stubs": {
             "hashes": [
-                "sha256:26afba47cde33b609ba974decd8272e2fd401bc0dc47521fb434210ecbb1914a",
-                "sha256:d760c4c1c024df72a2bf047bc35e3fb0050ac7bdb6d43f4d763ae326cb264a21"
+                "sha256:282d02b5db5c55486901c3a11f495de0d9117a5d329fa33a8f952571960dfd34",
+                "sha256:6771b23b965ab20205a9352a1fe270467ca0c813320651f2b477e756e75f7a3c"
             ],
             "index": "pypi",
-            "version": "==1.20.46.post1"
+            "version": "==1.20.48"
         },
         "botocore": {
             "hashes": [
-                "sha256:354bce55e5adc8e2fe106acfd455ce448f9b920d7b697d06faa8cf200fd6566b",
-                "sha256:38dd4564839f531725b667db360ba7df2125ceb3752b0ba12759c3e918015b95"
+                "sha256:768acb9a2247155b974a4184b29be321242ef8f61827f4bb958e60f00e476e90",
+                "sha256:8652c11ff05d11d6cea7096aca8df7f8eb87980469860036ff47e196e4625c96"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.23.46"
+            "version": "==1.23.48"
         },
         "botocore-stubs": {
             "hashes": [
-                "sha256:4d1a3a6f6d21e418ff59417b8f9713e8194cbb7b8125ab162300257e715ed6d1",
-                "sha256:adb6289c5c12af56767bd3d58480752d52a2aa3df19fc6bff82508701114a2c4"
+                "sha256:0360f24bf712c203fd8d78a53101021be07e34cdaad548d0902df6c3b94ae465",
+                "sha256:6516306b3e8dfb91c5e62003a333538039dd885f32440a804662aa7a8489b5b8"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.23.46.post1"
+            "version": "==1.23.48"
         },
         "certifi": {
             "hashes": [
@@ -97,11 +97,11 @@
         },
         "mypy-boto3-dynamodb": {
             "hashes": [
-                "sha256:77e9868fb4cdf89b21d85dabac94c59534dee398844e7f29c41dd8552b9a9211",
-                "sha256:b9058408b737292df15e4fe59c79c8d0b7f17c1197dee22b1c142d9bc22115b3"
+                "sha256:2cdfa78c90e66637f75a49d27367c13c8f9e69f58c2f6f0d5f2f52900cd353d2",
+                "sha256:701a9c40b371ebd5e05ebab443f218597ff1fe730a365777a46487167d2036cf"
             ],
             "index": "pypi",
-            "version": "==1.20.46.post1"
+            "version": "==1.20.47"
         },
         "mypy-boto3-s3": {
             "hashes": [
@@ -137,11 +137,11 @@
         },
         "s3transfer": {
             "hashes": [
-                "sha256:50ed823e1dc5868ad40c8dc92072f757aa0e653a192845c94a3b676f4a62da4c",
-                "sha256:9c1dc369814391a6bda20ebbf4b70a0f34630592c9aa520856bf384916af2803"
+                "sha256:25c140f5c66aa79e1ac60be50dcd45ddc59e83895f062a3aab263b870102911f",
+                "sha256:69d264d3e760e569b78aaa0f22c97e955891cd22e32b10c51f784eeda4d9d10a"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==0.5.0"
+            "version": "==0.5.1"
         },
         "six": {
             "hashes": [
@@ -208,19 +208,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:a2ffce001160d7e7c72a90c3084700d50eb64ea4a3aae8afe21566971d1fd611",
-                "sha256:d7effba509d7298ef49316ba2da7a2ea115f2a7ff691f875f6354666663cf386"
+                "sha256:1c6301d9676cb18f2b0feddec393e52b9d5fa8147e6fe9a1665e39fd9739efc3",
+                "sha256:6a8111492a571aeefbac2e4b6df5ce38bdbc16c7d8326f2a60a61c86032c49b0"
             ],
             "index": "pypi",
-            "version": "==1.20.46"
+            "version": "==1.20.48"
         },
         "botocore": {
             "hashes": [
-                "sha256:354bce55e5adc8e2fe106acfd455ce448f9b920d7b697d06faa8cf200fd6566b",
-                "sha256:38dd4564839f531725b667db360ba7df2125ceb3752b0ba12759c3e918015b95"
+                "sha256:768acb9a2247155b974a4184b29be321242ef8f61827f4bb958e60f00e476e90",
+                "sha256:8652c11ff05d11d6cea7096aca8df7f8eb87980469860036ff47e196e4625c96"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.23.46"
+            "version": "==1.23.48"
         },
         "certifi": {
             "hashes": [
@@ -321,53 +321,50 @@
                 "toml"
             ],
             "hashes": [
-                "sha256:012157499ec4f135fc36cd2177e3d1a1840af9b236cbe80e9a5ccfc83d912a69",
-                "sha256:0a34d313105cdd0d3644c56df2d743fe467270d6ab93b5d4a347eb9fec8924d6",
-                "sha256:11e61c5548ecf74ea1f8b059730b049871f0e32b74f88bd0d670c20c819ad749",
-                "sha256:152cc2624381df4e4e604e21bd8e95eb8059535f7b768c1fb8b8ae0b26f47ab0",
-                "sha256:1b4285fde5286b946835a1a53bba3ad41ef74285ba9e8013e14b5ea93deaeafc",
-                "sha256:27a94db5dc098c25048b0aca155f5fac674f2cf1b1736c5272ba28ead2fc267e",
-                "sha256:27ac7cb84538e278e07569ceaaa6f807a029dc194b1c819a9820b9bb5dbf63ab",
-                "sha256:2a491e159294d756e7fc8462f98175e2d2225e4dbe062cca7d3e0d5a75ba6260",
-                "sha256:2bc85664b06ba42d14bb74d6ddf19d8bfc520cb660561d2d9ce5786ae72f71b5",
-                "sha256:32168001f33025fd756884d56d01adebb34e6c8c0b3395ca8584cdcee9c7c9d2",
-                "sha256:3c4ce3b647bd1792d4394f5690d9df6dc035b00bcdbc5595099c01282a59ae01",
-                "sha256:433b99f7b0613bdcdc0b00cc3d39ed6d756797e3b078d2c43f8a38288520aec6",
-                "sha256:4578728c36de2801c1deb1c6b760d31883e62e33f33c7ba8f982e609dc95167d",
-                "sha256:509c68c3e2015022aeda03b003dd68fa19987cdcf64e9d4edc98db41cfc45d30",
-                "sha256:51372e24b1f7143ee2df6b45cff6a721f3abe93b1e506196f3ffa4155c2497f7",
-                "sha256:5d008e0f67ac800b0ca04d7914b8501312c8c6c00ad8c7ba17754609fae1231a",
-                "sha256:649df3641eb351cdfd0d5533c92fc9df507b6b2bf48a7ef8c71ab63cbc7b5c3c",
-                "sha256:6e78b1e25e5c5695dea012be473e442f7094d066925604be20b30713dbd47f89",
-                "sha256:72d9d186508325a456475dd05b1756f9a204c7086b07fffb227ef8cee03b1dc2",
-                "sha256:7d82c610a2e10372e128023c5baf9ce3d270f3029fe7274ff5bc2897c68f1318",
-                "sha256:7ee317486593193e066fc5e98ac0ce712178c21529a85c07b7cb978171f25d53",
-                "sha256:7eed8459a2b81848cafb3280b39d7d49950d5f98e403677941c752e7e7ee47cb",
-                "sha256:823f9325283dc9565ba0aa2d240471a93ca8999861779b2b6c7aded45b58ee0f",
-                "sha256:85c5fc9029043cf8b07f73fbb0a7ab6d3b717510c3b5642b77058ea55d7cacde",
-                "sha256:86c91c511853dfda81c2cf2360502cb72783f4b7cebabef27869f00cbe1db07d",
-                "sha256:8e0c3525b1a182c8ffc9bca7e56b521e0c2b8b3e82f033c8e16d6d721f1b54d6",
-                "sha256:987a84ff98a309994ca77ed3cc4b92424f824278e48e4bf7d1bb79a63cfe2099",
-                "sha256:9ed3244b415725f08ca3bdf02ed681089fd95e9465099a21c8e2d9c5d6ca2606",
-                "sha256:a189036c50dcd56100746139a459f0d27540fef95b09aba03e786540b8feaa5f",
-                "sha256:a4748349734110fd32d46ff8897b561e6300d8989a494ad5a0a2e4f0ca974fc7",
-                "sha256:a5d79c9af3f410a2b5acad91258b4ae179ee9c83897eb9de69151b179b0227f5",
-                "sha256:a7596aa2f2b8fa5604129cfc9a27ad9beec0a96f18078cb424d029fdd707468d",
-                "sha256:ab4fc4b866b279740e0d917402f0e9a08683e002f43fa408e9655818ed392196",
-                "sha256:bde4aeabc0d1b2e52c4036c54440b1ad05beeca8113f47aceb4998bb7471e2c2",
-                "sha256:c72bb4679283c6737f452eeb9b2a0e570acaef2197ad255fb20162adc80bea76",
-                "sha256:c8582e9280f8d0f38114fe95a92ae8d0790b56b099d728cc4f8a2e14b1c4a18c",
-                "sha256:ca29c352389ea27a24c79acd117abdd8a865c6eb01576b6f0990cd9a4e9c9f48",
-                "sha256:ce443a3e6df90d692c38762f108fc4c88314bf477689f04de76b3f252e7a351c",
-                "sha256:d1675db48490e5fa0b300f6329ecb8a9a37c29b9ab64fa9c964d34111788ca2d",
-                "sha256:da1a428bdbe71f9a8c270c7baab29e9552ac9d0e0cba5e7e9a4c9ee6465d258d",
-                "sha256:e4ff163602c5c77e7bb4ea81ba5d3b793b4419f8acd296aae149370902cf4e92",
-                "sha256:e67ccd53da5958ea1ec833a160b96357f90859c220a00150de011b787c27b98d",
-                "sha256:e8071e7d9ba9f457fc674afc3de054450be2c9b195c470147fbbc082468d8ff7",
-                "sha256:fff16a30fdf57b214778eff86391301c4509e327a65b877862f7c929f10a4253"
+                "sha256:1245ab82e8554fa88c4b2ab1e098ae051faac5af829efdcf2ce6b34dccd5567c",
+                "sha256:1bc6d709939ff262fd1432f03f080c5042dc6508b6e0d3d20e61dd045456a1a0",
+                "sha256:25e73d4c81efa8ea3785274a2f7f3bfbbeccb6fcba2a0bdd3be9223371c37554",
+                "sha256:276b13cc085474e482566c477c25ed66a097b44c6e77132f3304ac0b039f83eb",
+                "sha256:2aed4761809640f02e44e16b8b32c1a5dee5e80ea30a0ff0912158bde9c501f2",
+                "sha256:2dd70a167843b4b4b2630c0c56f1b586fe965b4f8ac5da05b6690344fd065c6b",
+                "sha256:352c68e233409c31048a3725c446a9e48bbff36e39db92774d4f2380d630d8f8",
+                "sha256:3f2b05757c92ad96b33dbf8e8ec8d4ccb9af6ae3c9e9bd141c7cc44d20c6bcba",
+                "sha256:448d7bde7ceb6c69e08474c2ddbc5b4cd13c9e4aa4a717467f716b5fc938a734",
+                "sha256:463e52616ea687fd323888e86bf25e864a3cc6335a043fad6bbb037dbf49bbe2",
+                "sha256:482fb42eea6164894ff82abbcf33d526362de5d1a7ed25af7ecbdddd28fc124f",
+                "sha256:56c4a409381ddd7bbff134e9756077860d4e8a583d310a6f38a2315b9ce301d0",
+                "sha256:56d296cbc8254a7dffdd7bcc2eb70be5a233aae7c01856d2d936f5ac4e8ac1f1",
+                "sha256:5e15d424b8153756b7c903bde6d4610be0c3daca3986173c18dd5c1a1625e4cd",
+                "sha256:618eeba986cea7f621d8607ee378ecc8c2504b98b3fdc4952b30fe3578304687",
+                "sha256:61d47a897c1e91f33f177c21de897267b38fbb45f2cd8e22a710bcef1df09ac1",
+                "sha256:621f6ea7260ea2ffdaec64fe5cb521669984f567b66f62f81445221d4754df4c",
+                "sha256:6a5cdc3adb4f8bb8d8f5e64c2e9e282bc12980ef055ec6da59db562ee9bdfefa",
+                "sha256:6c3f6158b02ac403868eea390930ae64e9a9a2a5bbfafefbb920d29258d9f2f8",
+                "sha256:704f89b87c4f4737da2860695a18c852b78ec7279b24eedacab10b29067d3a38",
+                "sha256:72128176fea72012063200b7b395ed8a57849282b207321124d7ff14e26988e8",
+                "sha256:78fbb2be068a13a5d99dce9e1e7d168db880870f7bc73f876152130575bd6167",
+                "sha256:7bff3a98f63b47464480de1b5bdd80c8fade0ba2832c9381253c9b74c4153c27",
+                "sha256:84f2436d6742c01136dd940ee158bfc7cf5ced3da7e4c949662b8703b5cd8145",
+                "sha256:9976fb0a5709988778ac9bc44f3d50fccd989987876dfd7716dee28beed0a9fa",
+                "sha256:9ad0a117b8dc2061ce9461ea4c1b4799e55edceb236522c5b8f958ce9ed8fa9a",
+                "sha256:9e3dd806f34de38d4c01416344e98eab2437ac450b3ae39c62a0ede2f8b5e4ed",
+                "sha256:9eb494070aa060ceba6e4bbf44c1bc5fa97bfb883a0d9b0c9049415f9e944793",
+                "sha256:9fde6b90889522c220dd56a670102ceef24955d994ff7af2cb786b4ba8fe11e4",
+                "sha256:9fff3ff052922cb99f9e52f63f985d4f7a54f6b94287463bc66b7cdf3eb41217",
+                "sha256:a06c358f4aed05fa1099c39decc8022261bb07dfadc127c08cfbd1391b09689e",
+                "sha256:a4f923b9ab265136e57cc14794a15b9dcea07a9c578609cd5dbbfff28a0d15e6",
+                "sha256:c5b81fb37db76ebea79aa963b76d96ff854e7662921ce742293463635a87a78d",
+                "sha256:d5ed164af5c9078596cfc40b078c3b337911190d3faeac830c3f1274f26b8320",
+                "sha256:d651fde74a4d3122e5562705824507e2f5b2d3d57557f1916c4b27635f8fbe3f",
+                "sha256:de73fca6fb403dd72d4da517cfc49fcf791f74eee697d3219f6be29adf5af6ce",
+                "sha256:e647a0be741edbb529a72644e999acb09f2ad60465f80757da183528941ff975",
+                "sha256:e92c7a5f7d62edff50f60a045dc9542bf939758c95b2fcd686175dd10ce0ed10",
+                "sha256:eeffd96882d8c06d31b65dddcf51db7c612547babc1c4c5db6a011abe9798525",
+                "sha256:f5a4551dfd09c3bd12fca8144d47fe7745275adf3229b7223c2f9e29a975ebda",
+                "sha256:fac0bcc5b7e8169bffa87f0dcc24435446d329cbc2b5486d155c2e0f3b493ae1"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==6.3"
+            "version": "==6.3.1"
         },
         "cryptography": {
             "hashes": [
@@ -418,13 +415,21 @@
             "index": "pypi",
             "version": "==4.0.1"
         },
+        "freezegun": {
+            "hashes": [
+                "sha256:177f9dd59861d871e27a484c3332f35a6e3f5d14626f2bf91be37891f18927f3",
+                "sha256:2ae695f7eb96c62529f03a038461afe3c692db3465e215355e1bb4b0ab408712"
+            ],
+            "index": "pypi",
+            "version": "==1.1.0"
+        },
         "identify": {
             "hashes": [
-                "sha256:8408f01e0be25492017346d7dffe7e7711b762b23375c775d24d3bc38618fabc",
-                "sha256:e64210654dfbca6ced33230eb1b137591a0981425e1a60b4c6c36309f787bbd5"
+                "sha256:97e839c1779f07011b84c92af183e1883d9745d532d83412cca1ca76d3808c1c",
+                "sha256:a55bdd671b6063eb837af938c250ec00bba6e610454265133b0d2db7ae718d0f"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.4.7"
+            "version": "==2.4.8"
         },
         "idna": {
             "hashes": [
@@ -649,11 +654,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89",
-                "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"
+                "sha256:42901e6bd4bd4a0e533358a86e848427a49005a3256f657c5c8f8dd35ef137a9",
+                "sha256:dad48ffda394e5ad9aa3b7d7ddf339ed502e5e365b1350e0af65f4a602344b11"
             ],
             "index": "pypi",
-            "version": "==6.2.5"
+            "version": "==7.0.0"
         },
         "pytest-cov": {
             "hashes": [
@@ -727,19 +732,19 @@
         },
         "responses": {
             "hashes": [
-                "sha256:e4fc472fb7374fb8f84fcefa51c515ca4351f198852b4eb7fc88223780b472ea",
-                "sha256:ec675e080d06bf8d1fb5e5a68a1e5cd0df46b09c78230315f650af5e4036bec7"
+                "sha256:15c63ad16de13ee8e7182d99c9334f64fd81f1ee79f90748d527c28f7ca9dd51",
+                "sha256:380cad4c1c1dc942e5e8a8eaae0b4d4edf708f4f010db8b7bcfafad1fcd254ff"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==0.17.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==0.18.0"
         },
         "s3transfer": {
             "hashes": [
-                "sha256:50ed823e1dc5868ad40c8dc92072f757aa0e653a192845c94a3b676f4a62da4c",
-                "sha256:9c1dc369814391a6bda20ebbf4b70a0f34630592c9aa520856bf384916af2803"
+                "sha256:25c140f5c66aa79e1ac60be50dcd45ddc59e83895f062a3aab263b870102911f",
+                "sha256:69d264d3e760e569b78aaa0f22c97e955891cd22e32b10c51f784eeda4d9d10a"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==0.5.0"
+            "version": "==0.5.1"
         },
         "six": {
             "hashes": [

--- a/lambda.py
+++ b/lambda.py
@@ -1,8 +1,0 @@
-import json
-
-from src.actualizer import Actualizer
-
-
-def lambda_handler(event, context):
-    Actualizer().get_stocks_and_publish_messages()
-    return {"statusCode": 200, "body": json.dumps("wolf or robinhood!")}

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -1,0 +1,24 @@
+import json
+
+from src.actualizer import Actualizer
+
+
+def lambda_handler(event, context):
+    # create actualizer
+    actualizer = Actualizer()
+
+    # get users from database
+    users = actualizer.get_users()
+
+    # get all the stock data that the users want to track
+    stock_quotes = actualizer.get_stock_quotes(users)
+
+    # publish alert messages if user provided thresholds are breached
+    actualizer.publish_alert_messages(users, stock_quotes)
+
+    # write invocation digest to s3 bucket
+    actualizer.write_digest_to_s3_bucket(users, stock_quotes)
+
+    # TODO: Write logs to file and upload to s3 bucket
+
+    return {"statusCode": 200, "body": json.dumps("wolf or robinhood!")}

--- a/src/actualizer.py
+++ b/src/actualizer.py
@@ -1,10 +1,14 @@
 from dataclasses import dataclass
-from src.models.user import User
-from src.yf_api_controller import YFApiController
+from typing import Dict, List, Set
+
 from src.gateways.dynamodb_gateway import DynamoDbGateway
+from src.gateways.s3_gateway import S3Gateway
 from src.gateways.sns_gateway import SnsGateway
-from typing import List, Set
+from src.models.stock_quote import StockQuote
+from src.models.user import User
+from src.utils.csv_generator import CsvGenerator
 from src.utils.logger import Logger
+from src.yf_api_controller import YFApiController
 
 log = Logger(__name__).get_logger()
 
@@ -14,19 +18,19 @@ class Actualizer:
 
     yf_api: YFApiController = YFApiController()
     dynamodb_gateway: DynamoDbGateway = DynamoDbGateway()
+    s3_gateway: S3Gateway = S3Gateway()
     sns_gateway: SnsGateway = SnsGateway()
+    csv_generator: CsvGenerator = CsvGenerator()
 
-    def get_stocks_and_publish_messages(self):
-        # get user strike prices
-        users = self.dynamodb_gateway.get_users()
+    def get_users(self) -> List[User]:
+        return self.dynamodb_gateway.get_users()
 
-        # get set of stocks to query
-        symbols = self._get_symbols(users)
+    def get_stock_quotes(self, users: List[User]) -> Dict[str, StockQuote]:
+        return self.yf_api.get_stock_quotes(symbols=self._get_symbols(users))
 
-        # query yf api for user strike prices
-        stock_quotes = self.yf_api.get_stock_quotes(symbols=symbols)
-
-        # do comparison and publish sns message if criteria is met
+    def publish_alert_messages(
+        self, users: List[User], stock_quotes: Dict[str, StockQuote]
+    ) -> None:
         for user in users:
             for strike_price in user.strike_prices:
                 market_price = stock_quotes[strike_price.symbol].market_price
@@ -42,7 +46,7 @@ class Actualizer:
                         f"The Wolf of Robinhood Team"
                     )
                     self.sns_gateway.publish_message(message=msg)
-                if strike_price.sell_price < market_price:
+                elif strike_price.sell_price < market_price:
                     log.info(
                         f"Sending sell alert message for stock {strike_price.symbol} to email {user.email} and phone number {user.phone_number}"
                     )
@@ -54,6 +58,13 @@ class Actualizer:
                         f"The Wolf of Robinhood Team"
                     )
                     self.sns_gateway.publish_message(message=msg)
+
+    def write_digest_to_s3_bucket(
+        self, users: List[User], stock_quotes: Dict[str, StockQuote]
+    ) -> None:
+        self.csv_generator.generate_csv(users, stock_quotes)
+        self.s3_gateway.upload_file(file_name="data.csv", key="data.csv")
+        self.s3_gateway.upload_file(file_name="logs.log", key="logs.log")
 
     @staticmethod
     def _get_symbols(users: List[User]) -> Set[str]:

--- a/src/gateways/s3_gateway.py
+++ b/src/gateways/s3_gateway.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from mypy_boto3_s3 import S3Client
 from src.gateways.clients import s3
 from src.utils.logger import Logger
+from datetime import date
 
 log = Logger(__name__).get_logger()
 
@@ -12,10 +13,13 @@ log = Logger(__name__).get_logger()
 class S3Gateway:
 
     client: S3Client = s3
-    bucket: str = os.getenv("AWS_BUCKET")
+    bucket: str = os.getenv("S3_BUCKET")
 
     def upload_file(self, file_name: str, key: str) -> None:
+        key_with_datestamp = str(date.today()) + "/" + key
         log.info(
-            f"Uploading {file_name} to S3 bucket {self.bucket} with key {key}....."
+            f"Uploading {file_name} to S3 bucket {self.bucket} with key {key_with_datestamp}....."
         )
-        self.client.upload_file(Filename=file_name, Bucket=self.bucket, Key=key)
+        self.client.upload_file(
+            Filename=file_name, Bucket=self.bucket, Key=key_with_datestamp
+        )

--- a/src/utils/csv_generator.py
+++ b/src/utils/csv_generator.py
@@ -1,0 +1,45 @@
+import csv
+from dataclasses import dataclass
+from typing import Dict, List
+
+from src.models.stock_quote import StockQuote
+from src.models.user import User
+
+
+@dataclass
+class CsvGenerator:
+
+    file_name: str = "data.csv"
+    working_dir: str = "./"
+
+    def generate_csv(
+        self, users: List[User], stock_quotes: Dict[str, StockQuote]
+    ) -> None:
+        data = []
+        for user in users:
+            for strike_price in user.strike_prices:
+                data.append(
+                    [
+                        user.email,
+                        strike_price.symbol,
+                        strike_price.buy_price,
+                        strike_price.sell_price,
+                        stock_quotes[strike_price.symbol].market_price,
+                    ]
+                )
+        self._write_csv(
+            column_headers=[
+                "email",
+                "stock",
+                "buy price",
+                "sell price",
+                "market price",
+            ],
+            data=data,
+        )
+
+    def _write_csv(self, column_headers: list, data: List[list]) -> None:
+        csv_data_with_headers = [column_headers] + data
+        with open(self.working_dir + self.file_name, "w", newline="") as f:
+            csv_writer = csv.writer(f)
+            csv_writer.writerows(csv_data_with_headers)

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -1,9 +1,11 @@
 import os
 import sys
 from dataclasses import dataclass
-from logging import Formatter, Handler, Logger, StreamHandler, getLogger
+from logging import FileHandler, Formatter, Handler, Logger, StreamHandler, getLogger
 
 import coloredlogs
+
+LOG_FILE = "logs.log"
 
 
 @dataclass
@@ -21,10 +23,17 @@ class Logger:
         console_handler.setFormatter(self.formatter)
         return console_handler
 
+    def _get_file_handler(self, filename: str) -> Handler:
+        file_handler = FileHandler(filename, mode="a+")
+        file_handler.setLevel(self.log_level)
+        file_handler.setFormatter(self.formatter)
+        return file_handler
+
     def get_logger(self) -> Logger:
         logger = getLogger(self.name)
         logger.setLevel(self.log_level)
         logger.addHandler(self._get_console_handler())
+        logger.addHandler(self._get_file_handler(filename=LOG_FILE))
         coloredlogs.install(
             fmt="%(asctime)s :: %(levelname)s :: %(name)s :: %(message)s",
             level=self.log_level,

--- a/tests/test_s3_gateway.py
+++ b/tests/test_s3_gateway.py
@@ -1,6 +1,7 @@
 import pytest
 
 from src.gateways.s3_gateway import S3Gateway
+from freezegun import freeze_time
 
 
 class TestS3Gateway:
@@ -10,6 +11,10 @@ class TestS3Gateway:
         mock_s3.create_bucket(Bucket=self.bucket)
         self.s3_gateway = S3Gateway(client=mock_s3, bucket=self.bucket)
 
+    @freeze_time("2022-01-01")
     def test_upload_file(self, mock_s3):
         self.s3_gateway.upload_file(file_name="./tests/test.txt", key="test.txt")
-        assert mock_s3.get_object(Bucket=self.bucket, Key="test.txt") is not None
+        assert (
+            mock_s3.get_object(Bucket=self.bucket, Key="2022-01-01/test.txt")
+            is not None
+        )


### PR DESCRIPTION
This PR adds the feature of uploading the generated log file and a `data.csv` file to a S3 bucket on every invocation.

This feature is useful because it allows Wolf of Robinhood to have a recordkeeping of past runs with more information that what is simply stored in the CloudWatch logs. Also, because the `data.csv` file is in CSV format, we can easily parse this information later for post-processing analytics.