### PR TITLE
Changed Any Files Created to Write to /tmp Directory

### DIFF
--- a/src/actualizer.py
+++ b/src/actualizer.py
@@ -63,8 +63,8 @@ class Actualizer:
         self, users: List[User], stock_quotes: Dict[str, StockQuote]
     ) -> None:
         self.csv_generator.generate_csv(users, stock_quotes)
-        self.s3_gateway.upload_file(file_name="data.csv", key="data.csv")
-        self.s3_gateway.upload_file(file_name="logs.log", key="logs.log")
+        self.s3_gateway.upload_file(file_name="/tmp/data.csv", key="data.csv")
+        self.s3_gateway.upload_file(file_name="/tmp/logs.log", key="logs.log")
 
     @staticmethod
     def _get_symbols(users: List[User]) -> Set[str]:

--- a/src/utils/csv_generator.py
+++ b/src/utils/csv_generator.py
@@ -10,7 +10,7 @@ from src.models.user import User
 class CsvGenerator:
 
     file_name: str = "data.csv"
-    working_dir: str = "./"
+    working_dir: str = "/tmp/"
 
     def generate_csv(
         self, users: List[User], stock_quotes: Dict[str, StockQuote]

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -5,7 +5,7 @@ from logging import FileHandler, Formatter, Handler, Logger, StreamHandler, getL
 
 import coloredlogs
 
-LOG_FILE = "logs.log"
+LOG_FILE = "/tmp/logs.log"
 
 
 @dataclass


### PR DESCRIPTION
AWS Lambda runs on a read-only filesystem. So, if you want nonpersistent disk space for a lambda invocation to store any files before uploading to S3 or etc., you need to write the files to the `/tmp` directory.

So, this PR is the hotfix to write all files in the lambda function to the `/tmp` directory. This bug arose from the upload logs and data to S3 bucket feature in PR #7.