### PR TITLE
Send a Single Alert Email for Many Stock Price Breaches

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Lint with Flake8
         run: |
           pipenv install --dev
-          pipenv run flake8 --count --max-complexity=10 --max-line-length=127 --show-source --statistics --ignore=E501
+          pipenv run flake8 --count --max-complexity=10 --max-line-length=127 --show-source --statistics --ignore=E501,W503
         
       - name: Test with PyTest
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: flake8 # linter
         name: flake8
         description: "Flake8: Your tool for style guide enforcement"
-        entry: pipenv run flake8 --count --max-complexity=10 --max-line-length=127 --show-source --statistics --ignore=E501
+        entry: pipenv run flake8 --count --max-complexity=10 --max-line-length=127 --show-source --statistics --ignore=E501,W503
         language: python
         types: [ python ]
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ run:
 	pipenv run python test_local.py
 
 lint:
-	pipenv run flake8 --count --max-complexity=10 --max-line-length=127 --show-source --statistics --ignore=E501
+	pipenv run flake8 --count --max-complexity=10 --max-line-length=127 --show-source --statistics --ignore=E501,W503
 
 format:
 	pipenv run black .

--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ boto3-stubs = "*"
 mypy-boto3-dynamodb = "*"
 mypy-boto3-s3 = "*"
 mypy-boto3-sns = "*"
+tabulate = "*"
 
 [dev-packages]
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "534d2abb49d0f898922747d164d62df59641f8932f4699f1be2dcd6cd8b67d67"
+            "sha256": "914c191117d5aee8ea81689c8783c9ae702a7b18fe72312c6281918503e80739"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,35 +18,35 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:1c6301d9676cb18f2b0feddec393e52b9d5fa8147e6fe9a1665e39fd9739efc3",
-                "sha256:6a8111492a571aeefbac2e4b6df5ce38bdbc16c7d8326f2a60a61c86032c49b0"
+                "sha256:96f50e95bded5612ac8bd116d5d56a0cce4868870177805cb974d1f4f0a24b73",
+                "sha256:d96c1aa3edebff6466362e574af6d8a6f2f6c9c1d902d3c7efb0835e09f34ddb"
             ],
             "index": "pypi",
-            "version": "==1.20.48"
+            "version": "==1.20.53"
         },
         "boto3-stubs": {
             "hashes": [
-                "sha256:282d02b5db5c55486901c3a11f495de0d9117a5d329fa33a8f952571960dfd34",
-                "sha256:6771b23b965ab20205a9352a1fe270467ca0c813320651f2b477e756e75f7a3c"
+                "sha256:38509726fac8af459dfaf4481cf8a161ef49d7f9302dc92bbe5a1a2215881a1d",
+                "sha256:e72025d1c2df643ec9e9fd40dee29fe9e4fb238979fcbc3f5365b846c99e742b"
             ],
             "index": "pypi",
-            "version": "==1.20.48"
+            "version": "==1.20.53"
         },
         "botocore": {
             "hashes": [
-                "sha256:768acb9a2247155b974a4184b29be321242ef8f61827f4bb958e60f00e476e90",
-                "sha256:8652c11ff05d11d6cea7096aca8df7f8eb87980469860036ff47e196e4625c96"
+                "sha256:7a628bc8bb2573fbc77709c9e7a02061b750f6ebb8e961562de658eda98e140d",
+                "sha256:a97834aee61177e11618348ed8fe1963c37f319af628e6f875f1e0fbd587a9ec"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.23.48"
+            "version": "==1.23.53"
         },
         "botocore-stubs": {
             "hashes": [
-                "sha256:0360f24bf712c203fd8d78a53101021be07e34cdaad548d0902df6c3b94ae465",
-                "sha256:6516306b3e8dfb91c5e62003a333538039dd885f32440a804662aa7a8489b5b8"
+                "sha256:0e6f5fb67b6e22c8adb94954cf4f1614db71a0b0631e22318d7e9f2494745d69",
+                "sha256:6b6604faf967774085642b6e982f33b37d040a783ad5878cf4492d1d47222700"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.23.48"
+            "version": "==1.23.53"
         },
         "certifi": {
             "hashes": [
@@ -97,27 +97,27 @@
         },
         "mypy-boto3-dynamodb": {
             "hashes": [
-                "sha256:2cdfa78c90e66637f75a49d27367c13c8f9e69f58c2f6f0d5f2f52900cd353d2",
-                "sha256:701a9c40b371ebd5e05ebab443f218597ff1fe730a365777a46487167d2036cf"
+                "sha256:1688e4040932f199c3842ab0f5e23f933766004ed9dabdef84d6faf0732ec020",
+                "sha256:9031ded4c19aed1865e2a22ee1e45ae093cd5e6a8062efee47902ad8d207bb6c"
             ],
             "index": "pypi",
-            "version": "==1.20.47"
+            "version": "==1.20.49"
         },
         "mypy-boto3-s3": {
             "hashes": [
-                "sha256:ef8ef0046c9178f08918918971ef1360eb3ebc9fcdd35a2af4e44cc5d6b68d23",
-                "sha256:fb95b96532e139b235ed48792fb0460b1eeb50b508bb809f1524614663e9f548"
+                "sha256:4168b026010f7e1b6b6e4227c832cb345cc437cf147830f00f26e099dafd300f",
+                "sha256:74b0c71bcd6f5543b857c5720f82894d73ba2e8376f9f55011b594cd3e584a7f"
             ],
             "index": "pypi",
-            "version": "==1.20.46.post1"
+            "version": "==1.20.49"
         },
         "mypy-boto3-sns": {
             "hashes": [
-                "sha256:a2abeec99c642f7a0b436ad7b590c1d0e6075047865f03f0eae71c76538c798c",
-                "sha256:bb9ea3b2b9418b55013031d078fbe69b84c098e63cc80785d997204dd4ef1f3d"
+                "sha256:701d008fe1d748ff6f7c52a095634c879395d6ffd7a863f49af18eef1a387701",
+                "sha256:e29a2070e1817834c0242a08c065bf56f45ebea38267f69d38746d7d799ad5b9"
             ],
             "index": "pypi",
-            "version": "==1.20.46.post1"
+            "version": "==1.20.53"
         },
         "python-dateutil": {
             "hashes": [
@@ -150,6 +150,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
+        },
+        "tabulate": {
+            "hashes": [
+                "sha256:d7c013fe7abbc5e491394e10fa845f8f32fe54f8dc60c6622c6cf482d25d47e4",
+                "sha256:eb1d13f25760052e8931f2ef80aaf6045a6cceb47514db8beab24cded16f13a7"
+            ],
+            "index": "pypi",
+            "version": "==0.8.9"
         },
         "typing-extensions": {
             "hashes": [
@@ -208,19 +216,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:1c6301d9676cb18f2b0feddec393e52b9d5fa8147e6fe9a1665e39fd9739efc3",
-                "sha256:6a8111492a571aeefbac2e4b6df5ce38bdbc16c7d8326f2a60a61c86032c49b0"
+                "sha256:96f50e95bded5612ac8bd116d5d56a0cce4868870177805cb974d1f4f0a24b73",
+                "sha256:d96c1aa3edebff6466362e574af6d8a6f2f6c9c1d902d3c7efb0835e09f34ddb"
             ],
             "index": "pypi",
-            "version": "==1.20.48"
+            "version": "==1.20.53"
         },
         "botocore": {
             "hashes": [
-                "sha256:768acb9a2247155b974a4184b29be321242ef8f61827f4bb958e60f00e476e90",
-                "sha256:8652c11ff05d11d6cea7096aca8df7f8eb87980469860036ff47e196e4625c96"
+                "sha256:7a628bc8bb2573fbc77709c9e7a02061b750f6ebb8e961562de658eda98e140d",
+                "sha256:a97834aee61177e11618348ed8fe1963c37f319af628e6f875f1e0fbd587a9ec"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.23.48"
+            "version": "==1.23.53"
         },
         "certifi": {
             "hashes": [
@@ -425,11 +433,11 @@
         },
         "identify": {
             "hashes": [
-                "sha256:97e839c1779f07011b84c92af183e1883d9745d532d83412cca1ca76d3808c1c",
-                "sha256:a55bdd671b6063eb837af938c250ec00bba6e610454265133b0d2db7ae718d0f"
+                "sha256:bff7c4959d68510bc28b99d664b6a623e36c6eadc933f89a4e0a9ddff9b4fee4",
+                "sha256:e926ae3b3dc142b6a7a9c65433eb14ccac751b724ee255f7c2ed3b5970d764fb"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.4.8"
+            "version": "==2.4.9"
         },
         "idna": {
             "hashes": [
@@ -554,11 +562,11 @@
         },
         "moto": {
             "hashes": [
-                "sha256:b489cb7e794e4722afb9a0dd17e5009570c74e359c1cf4c3d7c2bce455e79427",
-                "sha256:bd9d68a1f3985241444c314ac129a27efbe7f9b0a2ffa350031bbde743589399"
+                "sha256:445a574395b8a43a249ae0f932bf10c5cc677054198bfa1ff92e6fbd60e72c38",
+                "sha256:fa3fbdc22c55d7e70b407e2f2639c48ac82b074f472b167609405c0c1e3a2ccb"
             ],
             "index": "pypi",
-            "version": "==3.0.2"
+            "version": "==3.0.3"
         },
         "mypy-extensions": {
             "hashes": [
@@ -591,11 +599,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:1d7385c7db91728b83efd0ca99a5afb296cab9d0ed8313a45ed8ba17967ecfca",
-                "sha256:440633ddfebcc36264232365d7840a970e75e1018d15b4327d11f91909045fda"
+                "sha256:30671902352e97b1eafd74ade8e4a694782bd3471685e78c32d0fdfd3aa7e7bb",
+                "sha256:8ec11dfba28ecc0715eb5fb0147a87b1bf325f349f3da9aab2cd6b50b96b692b"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.4.1"
+            "version": "==2.5.0"
         },
         "pluggy": {
             "hashes": [
@@ -764,11 +772,11 @@
         },
         "tomli": {
             "hashes": [
-                "sha256:b5bde28da1fed24b9bd1d4d2b8cba62300bfb4ec9a6187a957e8ddb9434c5224",
-                "sha256:c292c34f58502a1eb2bbb9f5bbc9a5ebc37bee10ffb8c2d6bbdfa8eb13cc14e1"
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.0.0"
+            "version": "==2.0.1"
         },
         "typing-extensions": {
             "hashes": [
@@ -788,19 +796,19 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:339f16c4a86b44240ba7223d0f93a7887c3ca04b5f9c8129da7958447d079b09",
-                "sha256:d8458cf8d59d0ea495ad9b34c2599487f8a7772d796f9910858376d1600dd2dd"
+                "sha256:45e1d053cad4cd453181ae877c4ffc053546ae99e7dd049b9ff1d9be7491abf7",
+                "sha256:e0621bcbf4160e4e1030f05065c8834b4e93f4fcc223255db2a823440aca9c14"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==20.13.0"
+            "version": "==20.13.1"
         },
         "werkzeug": {
             "hashes": [
-                "sha256:63d3dc1cf60e7b7e35e97fa9861f7397283b75d765afcaefd993d6046899de8f",
-                "sha256:aa2bb6fc8dee8d6c504c0ac1e7f5f7dc5810a9903e793b6f715a9f015bdadb9a"
+                "sha256:1421ebfc7648a39a5c58c601b154165d05cf47a3cd0ccb70857cbdacf6c8f2b8",
+                "sha256:b863f8ff057c522164b6067c9e28b041161b4be5ba4d0daceeaa50a163822d3c"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.0.2"
+            "version": "==2.0.3"
         },
         "xmltodict": {
             "hashes": [

--- a/src/aws_gateways/dynamodb_gateway.py
+++ b/src/aws_gateways/dynamodb_gateway.py
@@ -18,7 +18,6 @@ class DynamoDbGateway:
     strike_prices_table: str = os.getenv("STRIKE_PRICES_TABLE_NAME")
 
     def get_users(self) -> List[User]:
-        log.info(self.strike_prices_table)
         items = self.client.scan(TableName=self.strike_prices_table)["Items"]
         users = []
         for item in items:

--- a/src/models/alert.py
+++ b/src/models/alert.py
@@ -1,0 +1,69 @@
+from dataclasses import dataclass
+from src.models.stock_quote import StockQuote
+
+from src.models.strike_price import StrikePrice
+from tabulate import tabulate
+from typing import List
+from src.utils.logger import Logger
+
+log = Logger(__name__).get_logger()
+
+
+@dataclass
+class Alert:
+
+    user_email: str
+    strike_prices: List[StrikePrice]
+    stock_quotes: List[StockQuote]
+
+    def generate_alert_message(self) -> str:
+        log.info(
+            f"Sending alert message for {len(self.strike_prices)} stocks to user with email {self.user_email}....."
+        )
+        table = tabulate(
+            tabular_data=self._generate_tabular_data(
+                self.strike_prices, self.stock_quotes
+            ),
+            headers=[
+                "Stock",
+                "Buy",
+                "Sell",
+                "Market Price",
+                "Trailing PE",
+                "Forward PE",
+                "EPS Current Year",
+                "EPS Forward",
+                "EPS Trailing 12 Months",
+            ],
+            tablefmt="floatfmt",
+            numalign="right",
+        )
+        msg = (
+            f"Hello, {self.user_email}!\n\n"
+            f"Wolf of Robinhood has detected that {len(self.strike_prices)} of your stocks have breached the buy/sell criteria you specified."
+            f" Below is a table of the stocks and their associated metrics. Please buy and sell accordingly.\n\n"
+            f"{table}\n\n"
+            f"Thanks and have a great day!\n"
+            f"The Wolf of Robinhood Team"
+        )
+        return msg
+
+    def _generate_tabular_data(
+        self, strike_prices: List[StrikePrice], stock_quotes: List[StockQuote]
+    ) -> List[list]:
+        tabular_data = []
+        for strike_price, stock_quote in zip(strike_prices, stock_quotes):
+            tabular_data.append(
+                [
+                    strike_price.symbol,
+                    strike_price.buy_price,
+                    strike_price.sell_price,
+                    stock_quote.market_price,
+                    stock_quote.trailing_pe,
+                    stock_quote.forward_pe,
+                    stock_quote.eps_current_year,
+                    stock_quote.eps_forward,
+                    stock_quote.eps_trailing_twelve_months,
+                ]
+            )
+        return tabular_data


### PR DESCRIPTION
Beforehand, WOR alerter would send an email for every stock price that was breached on a single invocation. This leads to too many emails. So, this PR condenses the alerts to one email with a table format.

In the future, I might want to refactor the tool to use SES as opposed to SNS through AWS so that I can better format the emails.