### PR TITLE
SES Refactor: Send Alert Emails with Boto3 SES Client

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ mypy-boto3-dynamodb = "*"
 mypy-boto3-s3 = "*"
 mypy-boto3-sns = "*"
 tabulate = "*"
+mypy-boto3-ses = "*"
 
 [dev-packages]
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "914c191117d5aee8ea81689c8783c9ae702a7b18fe72312c6281918503e80739"
+            "sha256": "165bb1073d2ba3fb08470cf40af78157e10b5b892a0d72025ef6b8cb39f7bb5a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,35 +18,35 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:96f50e95bded5612ac8bd116d5d56a0cce4868870177805cb974d1f4f0a24b73",
-                "sha256:d96c1aa3edebff6466362e574af6d8a6f2f6c9c1d902d3c7efb0835e09f34ddb"
+                "sha256:1a272a1dd36414b1626a47bb580425203be0b5a34caa117f38a5e18adf21f918",
+                "sha256:8129ad42cc0120d1c63daa18512d6f0b1439e385b2b6e0fe987f116bdf795546"
             ],
             "index": "pypi",
-            "version": "==1.20.53"
+            "version": "==1.20.54"
         },
         "boto3-stubs": {
             "hashes": [
-                "sha256:38509726fac8af459dfaf4481cf8a161ef49d7f9302dc92bbe5a1a2215881a1d",
-                "sha256:e72025d1c2df643ec9e9fd40dee29fe9e4fb238979fcbc3f5365b846c99e742b"
+                "sha256:db57d83266b5e8c2accd8f32bfb100227761ab06bd69afe9c05dab6e9923c7b4",
+                "sha256:dc547bd79dee748f7cc2124748e36787b5919eb3fa4f0d68d070b9e1e03e5671"
             ],
             "index": "pypi",
-            "version": "==1.20.53"
+            "version": "==1.20.54"
         },
         "botocore": {
             "hashes": [
-                "sha256:7a628bc8bb2573fbc77709c9e7a02061b750f6ebb8e961562de658eda98e140d",
-                "sha256:a97834aee61177e11618348ed8fe1963c37f319af628e6f875f1e0fbd587a9ec"
+                "sha256:06ae8076c4dcf3d72bec4d37e5f2dce4a92a18a8cdaa3bfaa6e3b7b5e30a8d7e",
+                "sha256:4bb9ba16cccee5f5a2602049bc3e2db6865346b2550667f3013bdf33b0a01ceb"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.23.53"
+            "version": "==1.23.54"
         },
         "botocore-stubs": {
             "hashes": [
-                "sha256:0e6f5fb67b6e22c8adb94954cf4f1614db71a0b0631e22318d7e9f2494745d69",
-                "sha256:6b6604faf967774085642b6e982f33b37d040a783ad5878cf4492d1d47222700"
+                "sha256:287ccaf53c86c2b0968cf8e78e4bc3a3806183ff3978028a74c8d9a3aa665382",
+                "sha256:4df14880ca4a0e0565c148418ea6a9ae017b4963b9fb57684494f65e3ff1b2b3"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.23.53"
+            "version": "==1.23.54"
         },
         "certifi": {
             "hashes": [
@@ -57,11 +57,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:2842d8f5e82a1f6aa437380934d5e1cd4fcf2003b06fed6940769c164a480a45",
-                "sha256:98398a9d69ee80548c762ba991a4728bfc3836768ed226b3945908d1a688371c"
+                "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
+                "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.11"
+            "version": "==2.0.12"
         },
         "coloredlogs": {
             "hashes": [
@@ -107,6 +107,14 @@
             "hashes": [
                 "sha256:4168b026010f7e1b6b6e4227c832cb345cc437cf147830f00f26e099dafd300f",
                 "sha256:74b0c71bcd6f5543b857c5720f82894d73ba2e8376f9f55011b594cd3e584a7f"
+            ],
+            "index": "pypi",
+            "version": "==1.20.49"
+        },
+        "mypy-boto3-ses": {
+            "hashes": [
+                "sha256:51113d40729fbf1a591676e078f912db595690291bb1ee73e317237ef91a9c02",
+                "sha256:729eb4738d565dd4c777cd7ea4cb1c38e97f27d43cb909821a546b060c3437fb"
             ],
             "index": "pypi",
             "version": "==1.20.49"
@@ -161,11 +169,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e",
-                "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"
+                "sha256:ba97c5143e5bb067b57793c726dd857b1671d4b02ced273ca0538e71ff009095",
+                "sha256:c13180fbaa7cd97065a4915ceba012bdb31dc34743e63ddee16360161d358414"
             ],
             "markers": "python_version < '3.9'",
-            "version": "==4.0.1"
+            "version": "==4.1.0"
         },
         "urllib3": {
             "hashes": [
@@ -216,19 +224,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:96f50e95bded5612ac8bd116d5d56a0cce4868870177805cb974d1f4f0a24b73",
-                "sha256:d96c1aa3edebff6466362e574af6d8a6f2f6c9c1d902d3c7efb0835e09f34ddb"
+                "sha256:1a272a1dd36414b1626a47bb580425203be0b5a34caa117f38a5e18adf21f918",
+                "sha256:8129ad42cc0120d1c63daa18512d6f0b1439e385b2b6e0fe987f116bdf795546"
             ],
             "index": "pypi",
-            "version": "==1.20.53"
+            "version": "==1.20.54"
         },
         "botocore": {
             "hashes": [
-                "sha256:7a628bc8bb2573fbc77709c9e7a02061b750f6ebb8e961562de658eda98e140d",
-                "sha256:a97834aee61177e11618348ed8fe1963c37f319af628e6f875f1e0fbd587a9ec"
+                "sha256:06ae8076c4dcf3d72bec4d37e5f2dce4a92a18a8cdaa3bfaa6e3b7b5e30a8d7e",
+                "sha256:4bb9ba16cccee5f5a2602049bc3e2db6865346b2550667f3013bdf33b0a01ceb"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.23.53"
+            "version": "==1.23.54"
         },
         "certifi": {
             "hashes": [
@@ -302,11 +310,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:2842d8f5e82a1f6aa437380934d5e1cd4fcf2003b06fed6940769c164a480a45",
-                "sha256:98398a9d69ee80548c762ba991a4728bfc3836768ed226b3945908d1a688371c"
+                "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
+                "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.11"
+            "version": "==2.0.12"
         },
         "click": {
             "hashes": [
@@ -662,11 +670,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:42901e6bd4bd4a0e533358a86e848427a49005a3256f657c5c8f8dd35ef137a9",
-                "sha256:dad48ffda394e5ad9aa3b7d7ddf339ed502e5e365b1350e0af65f4a602344b11"
+                "sha256:9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db",
+                "sha256:e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171"
             ],
             "index": "pypi",
-            "version": "==7.0.0"
+            "version": "==7.0.1"
         },
         "pytest-cov": {
             "hashes": [
@@ -780,11 +788,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e",
-                "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"
+                "sha256:ba97c5143e5bb067b57793c726dd857b1671d4b02ced273ca0538e71ff009095",
+                "sha256:c13180fbaa7cd97065a4915ceba012bdb31dc34743e63ddee16360161d358414"
             ],
             "markers": "python_version < '3.9'",
-            "version": "==4.0.1"
+            "version": "==4.1.0"
         },
         "urllib3": {
             "hashes": [

--- a/src/actualizer.py
+++ b/src/actualizer.py
@@ -10,7 +10,7 @@ from src.models.user import User
 from src.utils.csv_generator import CsvGenerator
 from src.utils.logger import Logger
 from src.yahoo_finance.yf_api_controller import YFApiController
-from src.models.alert import Alert
+from src.aws_gateways.ses_gateway import SesGateway
 
 log = Logger(__name__).get_logger()
 
@@ -22,6 +22,7 @@ class Actualizer:
     yf_api: YFApiController = YFApiController()
     dynamodb_gateway: DynamoDbGateway = DynamoDbGateway()
     s3_gateway: S3Gateway = S3Gateway()
+    ses_gateway: SesGateway = SesGateway()
     sns_gateway: SnsGateway = SnsGateway()
     csv_generator: CsvGenerator = CsvGenerator()
 
@@ -46,12 +47,18 @@ class Actualizer:
                     alert_strike_prices.append(strike_price)
                     alert_stock_quotes.append(stock_quotes[strike_price.symbol])
             if len(alert_strike_prices) > 0:
-                self.sns_gateway.publish_message(
-                    message=Alert(
-                        user_email=user.email,
-                        strike_prices=alert_strike_prices,
-                        stock_quotes=alert_stock_quotes,
-                    ).generate_alert_message()
+                # self.sns_gateway.publish_message(
+                #     message=Alert(
+                #         user_email=user.email,
+                #         strike_prices=alert_strike_prices,
+                #         stock_quotes=alert_stock_quotes,
+                #     ).generate_alert_message()
+                # )
+                log.info(f"sending alert message to {user.email}")
+                self.ses_gateway.send_email(
+                    user=user,
+                    strike_prices=alert_strike_prices,
+                    stock_quotes=alert_stock_quotes,
                 )
 
     def write_digest_to_s3_bucket(

--- a/src/actualizer.py
+++ b/src/actualizer.py
@@ -4,7 +4,6 @@ from datetime import datetime
 
 from src.aws_gateways.dynamodb_gateway import DynamoDbGateway
 from src.aws_gateways.s3_gateway import S3Gateway
-from src.aws_gateways.sns_gateway import SnsGateway
 from src.models.stock_quote import StockQuote
 from src.models.user import User
 from src.utils.csv_generator import CsvGenerator
@@ -23,7 +22,6 @@ class Actualizer:
     dynamodb_gateway: DynamoDbGateway = DynamoDbGateway()
     s3_gateway: S3Gateway = S3Gateway()
     ses_gateway: SesGateway = SesGateway()
-    sns_gateway: SnsGateway = SnsGateway()
     csv_generator: CsvGenerator = CsvGenerator()
 
     def get_users(self) -> List[User]:
@@ -47,13 +45,6 @@ class Actualizer:
                     alert_strike_prices.append(strike_price)
                     alert_stock_quotes.append(stock_quotes[strike_price.symbol])
             if len(alert_strike_prices) > 0:
-                # self.sns_gateway.publish_message(
-                #     message=Alert(
-                #         user_email=user.email,
-                #         strike_prices=alert_strike_prices,
-                #         stock_quotes=alert_stock_quotes,
-                #     ).generate_alert_message()
-                # )
                 log.info(f"sending alert message to {user.email}")
                 self.ses_gateway.send_email(
                     user=user,

--- a/src/aws_gateways/clients.py
+++ b/src/aws_gateways/clients.py
@@ -1,11 +1,17 @@
 import os
 
 import boto3
+from mypy_boto3_dynamodb import DynamoDBClient
+from mypy_boto3_sns import SNSClient
+from mypy_boto3_s3 import S3Client
+from mypy_boto3_ses import SESClient
 
 AWS_REGION = os.getenv("AWS_REGION", "us-east-1")
 
-dynamodb = boto3.client("dynamodb", region_name=AWS_REGION)
+dynamodb: DynamoDBClient = boto3.client("dynamodb", region_name=AWS_REGION)
 
-s3 = boto3.client("s3")
+s3: S3Client = boto3.client("s3")
 
-sns = boto3.client("sns", region_name=AWS_REGION)
+ses: SESClient = boto3.client("ses", region_name=AWS_REGION)
+
+sns: SNSClient = boto3.client("sns", region_name=AWS_REGION)

--- a/src/aws_gateways/ses_gateway.py
+++ b/src/aws_gateways/ses_gateway.py
@@ -1,0 +1,80 @@
+import os
+from dataclasses import dataclass
+from typing import List
+
+from mypy_boto3_ses import SESClient
+from src.aws_gateways.clients import ses
+from src.models.stock_quote import StockQuote
+from src.models.strike_price import StrikePrice
+from src.models.user import User
+
+SES_SOURCE_EMAIL = os.getenv("SES_SOURCE_EMAIL")
+SES_TEMPLATE = os.getenv("SES_TEMPLATE")
+
+
+@dataclass
+class SesGateway:
+
+    ses_client: SESClient = ses
+
+    # CRUD methods for templates
+    def get_template(self) -> None:
+        self.ses_client.get_template(TemplateName=SES_TEMPLATE)
+
+    def create_template(self) -> None:
+        self.ses_client.create_template(
+            Template={
+                "TemplateName": SES_TEMPLATE,
+                "SubjectPart": "",
+                "TextPart": "",
+                "HtmlPart": "",
+            }
+        )
+
+    def update_template(self, template_file_path: str, subject: str) -> None:
+        self.ses_client.update_template(
+            Template={
+                "TemplateName": SES_TEMPLATE,
+                "SubjectPart": subject,
+                "TextPart": "This is the text part",
+                "HtmlPart": open(template_file_path, "r").read(),
+            }
+        )
+
+    def delete_template(self) -> None:
+        self.ses_client.delete_template(TemplateName=SES_TEMPLATE)
+
+    def _generate_template_data(
+        self,
+        user: User,
+        strike_prices: List[StrikePrice],
+        stock_quotes: List[StockQuote],
+    ) -> str:
+        user_str = '{ "user": { "email": "%s" },' % user.email
+        strike_prices_str = ' "strike_prices": ['
+        for i, strike_price in enumerate(strike_prices):
+            strike_prices_str += (
+                ' { "symbol": "%s", "buy_price": %f, "sell_price": %f }'
+                % (strike_price.symbol, strike_price.buy_price, strike_price.sell_price)
+            )
+            if i != len(strike_prices) - 1:
+                strike_prices_str += ","
+        strike_prices_str += "]}"
+        template_data = user_str + strike_prices_str
+        return template_data
+
+    def send_email(
+        self,
+        user: User,
+        strike_prices: List[StrikePrice],
+        stock_quotes: List[StockQuote],
+    ) -> str:
+
+        return self.ses_client.send_templated_email(
+            Source=SES_SOURCE_EMAIL,
+            Destination={"ToAddresses": [user.email]},
+            Template=SES_TEMPLATE,
+            TemplateData=self._generate_template_data(
+                user=user, strike_prices=strike_prices, stock_quotes=stock_quotes
+            ),
+        )["MessageId"]

--- a/src/aws_gateways/ses_gateway.py
+++ b/src/aws_gateways/ses_gateway.py
@@ -52,10 +52,20 @@ class SesGateway:
     ) -> str:
         user_str = '{ "user": { "email": "%s" },' % user.email
         strike_prices_str = ' "strike_prices": ['
-        for i, strike_price in enumerate(strike_prices):
+        for i, stock in enumerate(zip(strike_prices, stock_quotes)):
             strike_prices_str += (
-                ' { "symbol": "%s", "buy_price": %f, "sell_price": %f }'
-                % (strike_price.symbol, strike_price.buy_price, strike_price.sell_price)
+                ' { "symbol": "%s", "buy_price": %.2f, "sell_price": %.2f, "market_price": %.2f, "trailing_pe": %.2f, "forward_pe": %.2f, "eps_current_year": %.2f, "eps_forward": %.2f, "eps_trailing_twelve_months": %.2f}'
+                % (
+                    stock[0].symbol,
+                    stock[0].buy_price,
+                    stock[0].sell_price,
+                    stock[1].market_price,
+                    stock[1].trailing_pe,
+                    stock[1].forward_pe,
+                    stock[1].eps_current_year,
+                    stock[1].eps_forward,
+                    stock[1].eps_trailing_twelve_months,
+                )
             )
             if i != len(strike_prices) - 1:
                 strike_prices_str += ","

--- a/src/email_templates/alert_email.html
+++ b/src/email_templates/alert_email.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+
+<body>
+    <h1>Wolf of Robinhood Alert!</h1>
+
+    <p>Hello {{user.email}}, Wolf of Robinhood has detected a breach in your buy/sell price criteria during our last
+        query of your watched stocks. Below is a table of the digest.</p>
+
+    <table>
+        <tr>
+            <th>Stock</th>
+            <th>Buy Price</th>
+            <th>Sell Price</th>
+        </tr>
+        {{#each strike_prices}}
+        <tr>
+            <td>{{symbol}}</td>
+            <td>{{buy_price}}</td>
+            <td>{{sell_price}}</td>
+        </tr>
+        {{/each}}
+    </table>
+
+    <p1>Best,</p1>
+    <br>
+    <p1>The Wolf of Robinhood Team</p1>
+</body>
+
+
+</html>

--- a/src/email_templates/alert_email.html
+++ b/src/email_templates/alert_email.html
@@ -12,12 +12,24 @@
             <th>Stock</th>
             <th>Buy Price</th>
             <th>Sell Price</th>
+            <th>Market Price</th>
+            <th>Trailing PE</th>
+            <th>Forward PE</th>
+            <th>EPS Current Year</th>
+            <th>EPS Forward</th>
+            <th>EPS Trailing 12 Months</th>
         </tr>
         {{#each strike_prices}}
         <tr>
             <td>{{symbol}}</td>
             <td>{{buy_price}}</td>
             <td>{{sell_price}}</td>
+            <td>{{market_price}}</td>
+            <td>{{trailing_pe}}</td>
+            <td>{{forward_pe}}</td>
+            <td>{{eps_current_year}}</td>
+            <td>{{eps_forward}}</td>
+            <td>{{eps_trailing_twelve_months}}</td>
         </tr>
         {{/each}}
     </table>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,13 @@ def mock_s3():
 
 
 @pytest.fixture
+def mock_ses():
+    mock_ses = moto.mock_ses()
+    mock_ses.start()
+    return boto3.client("ses", region_name=AWS_REGION)
+
+
+@pytest.fixture
 def mock_sns():
     mock_sns = moto.mock_sns()
     mock_sns.start()
@@ -40,6 +47,31 @@ def mock_users():
             ],
         )
     ]
+
+
+@pytest.fixture
+def mock_user():
+    return User(email="testuser@gmail.com", phone_number="0123456789")
+
+
+@pytest.fixture
+def mock_strike_price():
+    return StrikePrice(symbol="MSFT", buy_price=200.00, sell_price=300.00)
+
+
+@pytest.fixture
+def mock_stock_quote():
+    return StockQuote(
+        symbol="MSFT",
+        name="Microsoft",
+        currency="USD",
+        market_price=310.00,
+        trailing_pe=1,
+        forward_pe=1,
+        eps_current_year=1,
+        eps_forward=1,
+        eps_trailing_twelve_months=1,
+    )
 
 
 @pytest.fixture

--- a/tests/test_ses_gateway.py
+++ b/tests/test_ses_gateway.py
@@ -1,0 +1,34 @@
+import pytest
+import json
+from src.aws_gateways.ses_gateway import SesGateway
+
+
+class TestSesGateway:
+    @pytest.fixture(autouse=True)
+    def init_test_ses_gateway(self, mock_ses):
+        self.ses_gateway = SesGateway(ses_client=mock_ses)
+
+    def test_generate_template_data(
+        self, mock_user, mock_strike_price, mock_stock_quote
+    ):
+        template_data = self.ses_gateway._generate_template_data(
+            user=mock_user,
+            strike_prices=[mock_strike_price],
+            stock_quotes=[mock_stock_quote],
+        )
+        assert json.loads(template_data) == {
+            "user": {"email": "testuser@gmail.com"},
+            "strike_prices": [
+                {
+                    "symbol": "MSFT",
+                    "buy_price": 200.00,
+                    "sell_price": 300.00,
+                    "market_price": 310.00,
+                    "trailing_pe": 1.00,
+                    "forward_pe": 1.00,
+                    "eps_current_year": 1.00,
+                    "eps_forward": 1.00,
+                    "eps_trailing_twelve_months": 1.00,
+                }
+            ],
+        }

--- a/update_template.py
+++ b/update_template.py
@@ -1,0 +1,9 @@
+from src.aws_gateways.ses_gateway import SesGateway
+
+ses_gateway = SesGateway()
+
+response = ses_gateway.update_template(
+    template_file_path="./src/email_templates/alert_email.html", subject="69420"
+)
+
+print(response)


### PR DESCRIPTION
This PR includes the changes to send templated emails with `boto3` SES client.

This PR removes the dependency on `boto3` SNS client and utilizes SES client instead. The decision to make this refactor stemmed from the ability to send HTML-formatted emails with SES whereas SNS is incapable of doing so.

This PR address issue #12 